### PR TITLE
feat(KATT):Parse mid-line comments

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -139,7 +139,7 @@ class FattKATTCommand : AsyncCommand<FattKATTCommand.Settings>
                 Logger.Processing("Loading trigger regions from trigger_list.txt");
                 if(!File.Exists("./trigger_list.txt"))
                 {
-                    File.WriteAllText("./trigger_list.txt", "#trigger_list.txt\n#format is 1 trigger region per line.\n#lines can be commented out with hash marks.");
+                    File.WriteAllText("./trigger_list.txt", "#trigger_list.txt\n#format is 1 trigger region per line.\n#lines can be commented out with hash marks.\n#parts of lines after hash marks are also commented out.");
                     Logger.Info("File does not exist. Template created, please populate trigger_list.txt with list of trigger regions.");
                     Console.WriteLine("Press ENTER to continue."); Console.ReadLine();
                 }

--- a/Program.cs
+++ b/Program.cs
@@ -144,7 +144,7 @@ class FattKATTCommand : AsyncCommand<FattKATTCommand.Settings>
                     Console.WriteLine("Press ENTER to continue."); Console.ReadLine();
                 }
                 triggers = File.ReadAllText("./trigger_list.txt").Split("\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                triggers = triggers.Select(L=>L.Trim().Replace(' ','_')).Where(L => !L.StartsWith("#")).ToArray();
+                triggers = triggers.Select(L=>L.Split("#").First().Trim().Replace(' ','_')).Where(L => !string.IsNullOrEmpty(L) && !L.StartsWith("#")).ToArray();
                 if(triggers.Length == 0)
                 {
                     Logger.Error("Trigger list is empty. Please populate trigger_list.txt with list of trigger regions.");


### PR DESCRIPTION
### Description
This PR (hopefully) adds support for mid-line comments. For instance:
```py
# this comment was already supported
testregionia # this comment should work too now
```

I'm not sure what processes are in place for validating the checklist, so I've left it incomplete for now, but if there's anything I can help with there just let me know!


### Checklist
- [ ] Code compiles correctly
- [ ] Extended the README / documentation, if necessary
- [ ] No changes that violate NS Scripting rules
- [ ] All added features function properly on Win, OSX, and Linux